### PR TITLE
fix: extract GitHub releases with bsdtar for CodeBuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ VOLUME /var/lib/docker
 ADD det-arch.sh /usr/local/bin
 
 # base
-RUN dnf upgrade -y && dnf install -y sed wget curl kubernetes1.36-client git openssh-clients jq bc findutils unzip gawk openssl procps-ng which file ping clang && dnf clean all
+RUN dnf upgrade -y && dnf install -y sed wget curl kubernetes1.36-client git openssh-clients jq bc findutils unzip gawk openssl procps-ng which file ping clang bsdtar && dnf clean all
 
 # github
 ADD gh-scripts/* /usr/local/bin/

--- a/gh-scripts/extract-gh-release.sh
+++ b/gh-scripts/extract-gh-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 if [ $# -lt 2 ] ;then
     echo "Usage: <filename> <dstfolder>"
@@ -10,21 +10,9 @@ fi
 SRC_FILE="$1"
 DST_FOLDER="$2"
 
-mkdir -p $DST_FOLDER
+mkdir -p "$DST_FOLDER"
 
-# GitHub tarballs do not require preserving ownership, ACL/xattr, or SELinux labels.
-# Disabling those metadata restores avoids extraction failures on some CodeBuild
-# filesystems (e.g. "Function not implemented" from tar while creating files).
-tar \
-  --extract \
-  --gzip \
-  --verbose \
-  --file "$SRC_FILE" \
-  --strip-components=1 \
-  --directory "$DST_FOLDER" \
-  --no-same-owner \
-  --no-same-permissions \
-  --delay-directory-restore \
-  --no-xattrs \
-  --no-acls \
-  --no-selinux
+# Use bsdtar instead of GNU tar. Fedora 44+ GNU tar relies on openat2, which is
+# blocked by seccomp in some CI runtimes (e.g. AWS CodeBuild) and fails with
+# "Function not implemented" when extracting into subdirectories.
+bsdtar -xvzf "$SRC_FILE" -C "$DST_FOLDER" --strip-components 1


### PR DESCRIPTION
Fedora 44 GNU tar uses openat2, which CodeBuild seccomp blocks.